### PR TITLE
chore(images): add empty alt tags

### DIFF
--- a/packages/iteam-se/src/__tests__/__snapshots__/App.spec.tsx.snap
+++ b/packages/iteam-se/src/__tests__/__snapshots__/App.spec.tsx.snap
@@ -117,6 +117,7 @@ exports[`App renders App 1`] = `
               class="HomeHeader__Cloud-j7f4se-3 sc-kAzzGY bwQoic"
             />
             <img
+              alt=""
               src="test-file-stub"
               class="HomeHeader__IllustrationImage-j7f4se-4 bNOAKW"
             />
@@ -207,6 +208,7 @@ exports[`App renders App 1`] = `
       class="ImageBlock__Content-sc-15ih60h-0 hVrqrK"
     >
       <img
+        alt=""
         src="test-file-stub"
         class="ImageBlock__ImageContainer-sc-15ih60h-1 efhZFd"
       />
@@ -262,6 +264,7 @@ exports[`App renders App 1`] = `
           class="CTABlock__Content-sc-1dha9r9-1 kQKBtN"
         >
           <img
+            alt=""
             src="test-file-stub"
           />
           <div>

--- a/packages/iteam-se/src/components/Blocks/CTABlock.tsx
+++ b/packages/iteam-se/src/components/Blocks/CTABlock.tsx
@@ -55,7 +55,7 @@ const CTABlock: React.SFC<CTABlockProps> = ({
       <GridColumn>
         <PaddedRow data-test={`block-${dataTest}`}>
           <Content>
-            <img src={craneImage} />
+            <img alt="" src={craneImage} />
             <div>
               <H3>{title}</H3>
               <Text>{children}</Text>

--- a/packages/iteam-se/src/components/Blocks/ImageBleed.tsx
+++ b/packages/iteam-se/src/components/Blocks/ImageBleed.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import styled from '../../theme'
 
 interface ImageBleedProps {
+  alt?: string
   image: string
 }
 
@@ -11,8 +12,8 @@ const ImageContainer = styled.img`
   width: 100%;
 `
 
-const ImageBleed = ({ image }: ImageBleedProps) => {
-  return <ImageContainer src={image} />
+const ImageBleed = ({ alt = '', image }: ImageBleedProps) => {
+  return <ImageContainer alt={alt} src={image} />
 }
 
 export default ImageBleed

--- a/packages/iteam-se/src/components/Blocks/ImageBlock.tsx
+++ b/packages/iteam-se/src/components/Blocks/ImageBlock.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import styled from '../../theme'
 
 interface ImageBlockProps {
+  alt?: string
   column?: number
   image: string
 }
@@ -17,6 +18,7 @@ const Content = styled.div`
 `
 
 interface ImageContainerProps {
+  alt?: string
   column: number
 }
 
@@ -30,10 +32,14 @@ const ImageContainer = styled.img<ImageContainerProps>`
   }
 `
 
-const ImageBlock: React.SFC<ImageBlockProps> = ({ column = 6, image }) => {
+const ImageBlock: React.SFC<ImageBlockProps> = ({
+  alt = '',
+  column = 6,
+  image,
+}) => {
   return (
     <Content>
-      <ImageContainer column={column} src={image} />
+      <ImageContainer alt={alt} column={column} src={image} />
     </Content>
   )
 }

--- a/packages/iteam-se/src/components/Header/HomeHeader.tsx
+++ b/packages/iteam-se/src/components/Header/HomeHeader.tsx
@@ -178,7 +178,7 @@ const HomeHeader: React.SFC<HomeHeaderProps> = ({ title, lead }) => {
               <IllustrationWrap>
                 <Cloud />
                 <SmallCloud />
-                <IllustrationImage src={iteamI} />
+                <IllustrationImage alt="" src={iteamI} />
               </IllustrationWrap>
             </HomeMessageRow>
           </HomeContent>

--- a/packages/iteam-se/src/pages/NotFound.tsx
+++ b/packages/iteam-se/src/pages/NotFound.tsx
@@ -78,7 +78,7 @@ export const NotFound: React.SFC = () => {
         </Helmet>
         <HeaderClean />
         <Content>
-          <Broken alt="broken" src={brokenComputer} />
+          <Broken alt="" src={brokenComputer} />
           <Message>
             <StyledH1>Oj, någonting gick snett!</StyledH1>
             <Paragraph>{message}</Paragraph>

--- a/packages/iteam-se/src/pages/__tests__/__snapshots__/About.spec.tsx.snap
+++ b/packages/iteam-se/src/pages/__tests__/__snapshots__/About.spec.tsx.snap
@@ -174,6 +174,7 @@ exports[`components/About renders About 1`] = `
       class="ImageBlock__Content-sc-15ih60h-0 hVrqrK"
     >
       <img
+        alt=""
         src="test-file-stub"
         class="ImageBlock__ImageContainer-sc-15ih60h-1 efhZFd"
       />
@@ -215,6 +216,7 @@ exports[`components/About renders About 1`] = `
       </div>
     </div>
     <img
+      alt=""
       src="//images.ctfassets.net/rj4r6yfcesw5/7bwz7g2GuQu8A68QmCQAMw/2c6391a40ebe2d0bee958dacf72aa174/bleed_aboutus.jpg"
       class="ImageBleed__ImageContainer-sc-1jaho49-0 kEiPqu"
     />

--- a/packages/iteam-se/src/pages/__tests__/__snapshots__/Home.spec.tsx.snap
+++ b/packages/iteam-se/src/pages/__tests__/__snapshots__/Home.spec.tsx.snap
@@ -117,6 +117,7 @@ exports[`components/Home renders Home 1`] = `
               class="HomeHeader__Cloud-j7f4se-3 sc-dnqmqq jFHNyJ"
             />
             <img
+              alt=""
               src="test-file-stub"
               class="HomeHeader__IllustrationImage-j7f4se-4 bNOAKW"
             />
@@ -207,6 +208,7 @@ exports[`components/Home renders Home 1`] = `
       class="ImageBlock__Content-sc-15ih60h-0 hVrqrK"
     >
       <img
+        alt=""
         src="test-file-stub"
         class="ImageBlock__ImageContainer-sc-15ih60h-1 efhZFd"
       />
@@ -262,6 +264,7 @@ exports[`components/Home renders Home 1`] = `
           class="CTABlock__Content-sc-1dha9r9-1 kQKBtN"
         >
           <img
+            alt=""
             src="test-file-stub"
           />
           <div>

--- a/packages/iteam-se/src/pages/__tests__/__snapshots__/HowWeWork.spec.tsx.snap
+++ b/packages/iteam-se/src/pages/__tests__/__snapshots__/HowWeWork.spec.tsx.snap
@@ -132,6 +132,7 @@ exports[`components/HowWeWork renders HowWeWork 1`] = `
       class="ImageBlock__Content-sc-15ih60h-0 hVrqrK"
     >
       <img
+        alt=""
         src="test-file-stub"
         class="ImageBlock__ImageContainer-sc-15ih60h-1 efhZFd"
       />
@@ -244,6 +245,7 @@ exports[`components/HowWeWork renders HowWeWork 1`] = `
     </div>
   </div>
   <img
+    alt=""
     src="//images.ctfassets.net/rj4r6yfcesw5/62hgzE8G3ueMa2YSEuG4og/db2b643db6041f9d26936bc2d6006607/bleed_howwework.jpg"
     class="ImageBleed__ImageContainer-sc-1jaho49-0 kEiPqu"
   />
@@ -290,6 +292,7 @@ exports[`components/HowWeWork renders HowWeWork 1`] = `
       class="ImageBlock__Content-sc-15ih60h-0 hVrqrK"
     >
       <img
+        alt=""
         src="test-file-stub"
         class="ImageBlock__ImageContainer-sc-15ih60h-1 efhZFd"
       />

--- a/packages/iteam-se/src/pages/__tests__/__snapshots__/NotFound.spec.tsx.snap
+++ b/packages/iteam-se/src/pages/__tests__/__snapshots__/NotFound.spec.tsx.snap
@@ -30,7 +30,7 @@ exports[`components/NotFound renders NotFound 1`] = `
       class="NotFound__Content-xslswo-0 gCWvuc"
     >
       <img
-        alt="broken"
+        alt=""
         src="test-file-stub"
         class="NotFound__Broken-xslswo-1 kmugLl"
       />

--- a/packages/iteam-se/src/pages/__tests__/__snapshots__/OpenPosition.spec.tsx.snap
+++ b/packages/iteam-se/src/pages/__tests__/__snapshots__/OpenPosition.spec.tsx.snap
@@ -256,6 +256,7 @@ exports[`components/OpenPosition renders OpenPosition 1`] = `
       </div>
     </div>
     <img
+      alt=""
       src="//images.ctfassets.net/rj4r6yfcesw5/62hgzE8G3ueMa2YSEuG4og/db2b643db6041f9d26936bc2d6006607/bleed_howwework.jpg"
       class="ImageBleed__ImageContainer-sc-1jaho49-0 kEiPqu"
     />


### PR DESCRIPTION
Add empty alt-tags for illustrations and images. Empty tags is better than none because most screen readers will read out the link if no alt tag exists. Empty tags will be silent.

Silent alt tags are fine for most of our images because they just have a visual purpose or don't convey any extra information that isn't already described in the text.