### PR TITLE
chore: remove quotation marks

### DIFF
--- a/packages/iteam-se/src/components/Blocks/Quote.tsx
+++ b/packages/iteam-se/src/components/Blocks/Quote.tsx
@@ -59,7 +59,7 @@ const Quote: React.SFC<QuoteProps> = ({
   return (
     <QuoteWrap backgroundColor={quoteBgColor} data-test={`block-${dataTest}`}>
       <PaddedRow>
-        <ActualQuote>{`"${children}"`}</ActualQuote>
+        <ActualQuote>{`${children}`}</ActualQuote>
         <Person>{person}</Person>
       </PaddedRow>
     </QuoteWrap>

--- a/packages/iteam-se/src/pages/__tests__/__snapshots__/Case.spec.tsx.snap
+++ b/packages/iteam-se/src/pages/__tests__/__snapshots__/Case.spec.tsx.snap
@@ -235,7 +235,7 @@ exports[`components/Case renders Case 1`] = `
         <div
           class="Quote__ActualQuote-eij22x-0 jFvUu"
         >
-          ""We feel that our crew at Iteam are more colleagues than suppliers. Rather than specifying a tech spec to work on, we collaborate, carefully chiseling out functionality as we go along. This way of working has minimized waste and it has also taken us further than we ever imagined”"
+          "We feel that our crew at Iteam are more colleagues than suppliers. Rather than specifying a tech spec to work on, we collaborate, carefully chiseling out functionality as we go along. This way of working has minimized waste and it has also taken us further than we ever imagined”
         </div>
         <div
           class="Quote__Person-eij22x-1 eEHJCa"


### PR DESCRIPTION
This change removes quotation marks from the quote component. From now on we'll manually enter them in Contentful if we want them.
