### PR TITLE
fix: case markdown, image and quote

### DIFF
--- a/re/components/Block.re
+++ b/re/components/Block.re
@@ -15,11 +15,7 @@ module Markdown = {
   [@react.component]
   let make = (~source, ~className=?) => {
     <div className={Cn.make(["markdown", className->Cn.unpack])}>
-      {source
-       |> Js.String.replaceByRe([%re "/\\n\\s+/g"], "")
-       |> Dedent.make
-       |> Generate.make
-       |> Parse.make}
+      {source->Dedent.make->Generate.make->Parse.make}
     </div>;
   };
 };

--- a/re/models/Page.re
+++ b/re/models/Page.re
@@ -350,12 +350,16 @@ module Case = {
     };
 
     let make = headerData => {
-      url: headerData##file##url,
-      localFile:
-        switch (headerData##localFile->Js.Nullable.toOption) {
-        | Some(local) => Some(local##childImageSharp##fluid)
-        | None => None
-        },
+      headerData##file##url->Js.String2.includes("empty")
+        ? None
+        : Some({
+            url: headerData##file##url,
+            localFile:
+              switch (headerData##localFile->Js.Nullable.toOption) {
+              | Some(local) => Some(local##childImageSharp##fluid)
+              | None => None
+              },
+          });
     };
   };
 
@@ -376,7 +380,7 @@ module Case = {
   type t = {
     aboutCompany: string,
     aboutCompanyTitle: string,
-    casePageImage: FluidImage.t,
+    casePageImage: option(FluidImage.t),
     contact: option(string),
     contactTitle: option(string),
     contactSubtitle: option(string),
@@ -385,7 +389,7 @@ module Case = {
     developmentTitle: string,
     frameworks: option(array(string)),
     frameworksTitle: option(string),
-    header: FluidImage.t,
+    header: option(FluidImage.t),
     headerBgColor: string,
     introduction: string,
     introductionTitle: string,

--- a/re/pages/Case.re
+++ b/re/pages/Case.re
@@ -23,13 +23,17 @@ let make = (~data) => {
   let title = page.contactTitle;
 
   <>
-    <Block.Header
-      backgroundImage={page.header.url}
-      backgroundFluid={page.header.localFile}
-      color={`Other(page.headerBgColor)}
-      textColor=`White
-      messageOne={page.shortDescription}
-    />
+    {switch (page.header) {
+     | Some({url, localFile}) =>
+       <Block.Header
+         backgroundImage=url
+         backgroundFluid=localFile
+         color={`Other(page.headerBgColor)}
+         textColor=`White
+         messageOne={page.shortDescription}
+       />
+     | None => React.null
+     }}
     <Container className="md:mb-0 mb-0">
       <Breadcrumbs title={page.title} />
       <div className=Style.narrowContainer>
@@ -57,22 +61,22 @@ let make = (~data) => {
           </div>
         </Block.Case>
         <Block.Case title={`Text(page.introductionTitle)}>
-          <p> page.introduction->React.string </p>
+          <Block.Markdown source={page.introduction} />
         </Block.Case>
         <Block.Case title={`Text(page.processTitle)}>
-          <p> page.process->React.string </p>
+          <Block.Markdown source={page.process} />
         </Block.Case>
       </div>
-      <Block.Section color=`Concrete>
-        <img
-          className="justify-self-center"
-          width="720"
-          src={page.casePageImage.url}
-        />
-      </Block.Section>
+      {switch (page.casePageImage) {
+       | Some({url}) =>
+         <Block.Section color=`Concrete>
+           <img className="justify-self-center" width="720" src=url />
+         </Block.Section>
+       | None => React.null
+       }}
       <div className=Style.narrowContainer>
         <Block.Case title={`Text(page.developmentTitle)}>
-          <p> page.development->React.string </p>
+          <Block.Markdown source={page.development} />
         </Block.Case>
       </div>
       {page.quote
@@ -86,7 +90,7 @@ let make = (~data) => {
              }>
              <blockquote className="grid grid-gap-8-x col-start-2 col-end-2">
                <p className="md:text-3xl text-xl">
-                 {React.string({j|“$quote”|j})}
+                 {React.string({j|$quote|j})}
                </p>
                {page.quotePerson
                 ->Belt.Option.map(person =>
@@ -108,7 +112,7 @@ let make = (~data) => {
        ->Belt.Option.getWithDefault(React.null)}
       <div className=Style.narrowContainer>
         <Block.Case title={`Text(page.aboutCompanyTitle)}>
-          <p> page.aboutCompany->React.string </p>
+          <Block.Markdown source={page.aboutCompany} />
         </Block.Case>
       </div>
       {page.frameworksTitle

--- a/src/index.css
+++ b/src/index.css
@@ -127,7 +127,7 @@ table td {
   @apply min-w-full;
 }
 
-.markdown p:last-of-type {
+.markdown p:not(:last-of-type) {
   @apply mb-5;
 }
 


### PR DESCRIPTION
- Case texts uses markdown [#159](https://trello.com/c/jDbEipYG/159-formattering-f%C3%B6r-text-saknas)
- Remove quotes from case quote [#160](https://trello.com/c/ooUPK6FU/160-ta-bort-tecken-i-citatblocket)
- Case image is optional [#161](https://trello.com/c/97lMkW4K/161-ej-obligatoriskt-med-mockup-bild-p%C3%A5-casesidan)

Check https://iteamse-poc-git-fix-case-formatting.iteam.now.sh/case/skatteverket  (markdown and empty mockup image) and https://iteamse-poc-git-fix-case-formatting.iteam.now.sh/case/vimla (quote)